### PR TITLE
Add links to references to learn F#

### DIFF
--- a/chapters/audience.md
+++ b/chapters/audience.md
@@ -3,3 +3,8 @@
 Naturally, the book is aimed at F# developers who wish to use their existing knowledge and skills in F# to build front-end apps. Except for a bit of Html and CSS, no prior experience is assumed concerning front-end development as I will to try to explain the concepts needed from the very scratch.
 
 This book however is *not* an introduction to F# itself and I will assume you know the basics of language such as the general syntax, the concept of immutability, pattern matching and a bit of `Async`. I will try to keep it as simple as possible but this goes to say that I will not spend time explaining F# itself unless necessary.
+
+If you need to learn F# itself, both [the F# website][learn] and [Microsoft documentation][msdocs] are great starting points.
+
+[learn]:https://fsharp.org/learn.html
+[msdocs]:https://docs.microsoft.com/en-us/dotnet/fsharp/


### PR DESCRIPTION
This add a small paragraph in Audience after saying that this isn't the place to learn about F# itself to point users to where they might learn F#.