### PR TITLE
Fix typos and use synonyms

### DIFF
--- a/chapters/fable/README.md
+++ b/chapters/fable/README.md
@@ -1,6 +1,6 @@
 # Introduction
 
- This chapter provides a gentle introduction to Fable development by building Hello World and other small applications. We will not be using the Elm architecture just yet, instead, we will use the available browser APIs, particularty the [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document) API to play around a bit with elements on the browser pages and build small user interfaces.
+This chapter provides a gentle introduction to Fable development by building Hello World and other small applications. We will not be using Elm architecture just yet. Instead, we will use the available browser APIs, mainly the [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document) API to play around a bit with elements on the browser pages and build small user interfaces.
 
 ### Table of contents
 


### PR DESCRIPTION
I think that in general, we place `*` after the word.

So, I would probably rewrite the end of the page to:

```diff
- - [*Fable Packages](fable-packages.md)
+ - [Fable Packages*](fable-packages.md)
- - [*Fable Bindings](fable-bindings.md)
+ - [Fable Bindings*](fable-bindings.md)
- - [*Node.js Packages](node-packages.md)
+ - [Node.js Packages*](node-packages.md)
- - [*Understanding How Fable Works](how-fable-works.md)
+ - [Understanding How Fable Works*](how-fable-works.md)

- > *Advanced content.
+ > \* Advanced content.
```