### PR TITLE
Typos in JSON chapters

### DIFF
--- a/chapters/commands/working-with-json.md
+++ b/chapters/commands/working-with-json.md
@@ -2,7 +2,7 @@
 
 The information we get back from a web server using HTTP is usually not just plain text as in with the Lorem Ipsum snippet we retrieved in the previous section but very often the text we get back is *structured* where JSON is the most commonly used format to structure that text.
 
-> We usually say "We get JSON from the web server" as a short hand for "We get text back from the web server structured as JSON"
+> We usually say "We get JSON from the web server" as shorthand for "We get text back from the web server structured as JSON"
 
 Now understanding JSON and being able to parse the JSON-formatted text is essential to virtually every modern web application that communicates with an external web server as JSON is the de-facto format for the data being exchanged.
 
@@ -14,4 +14,4 @@ In Fable, there two main libraries to work with JSON:
 
 Automatic converters are used to let the library transform the JSON-formatted text into typed entities automatically by means of Reflection (F#/.NET mechanism for type-introspection), this works nicely for 99% of the time and saves you from having to write conversion code by yourself.
 
-In the rest of the this chapter, we will focus primarily on [Thoth.Json](https://mangelmaxime.github.io/Thoth/json/v3.html) because it has a really API to work with from Elmish applications. Fable.SimpleJson on the other hand, exposes a *low-level* API to manipulate and transform JSON itself which makes it more useful as a backbone for other libraries or infrastructure code. For example, Fable.SimpleJson is the power-engine behind [Fable.Remoting](https://github.com/Zaid-Ajaj/Fable.Remoting) and [Elmish.Bridge](https://github.com/Nhowka/Elmish.Bridge) where the library handles the deserialization of types on the front-end correctly and efficiently.
+In the rest of the this chapter, we will focus primarily on [Thoth.Json](https://mangelmaxime.github.io/Thoth/json/v3.html) because it has a really nice API to work with from Elmish applications. Fable.SimpleJson on the other hand, exposes a *low-level* API to manipulate and transform JSON itself which makes it more useful as a backbone for other libraries or infrastructure code. For example, Fable.SimpleJson is the power-engine behind [Fable.Remoting](https://github.com/Zaid-Ajaj/Fable.Remoting) and [Elmish.Bridge](https://github.com/Nhowka/Elmish.Bridge) where the library handles the deserialization of types on the front-end correctly and efficiently.


### PR DESCRIPTION
Fixing typos in using-json and working-with-json chapters.