### PR TITLE
Remove obsolete note about yield

### DIFF
--- a/chapters/elm/conditional-rendering.md
+++ b/chapters/elm/conditional-rendering.md
@@ -115,4 +115,3 @@ let render (state: State) (dispatch: Msg -> unit) =
     if state.Count > 0 then yield oddOrEvenMessage
   ]
 ```
-The only downside of this approach is that all other elements need to be `yield`ed as well. Because this pattern is used a lot in Fable/F# projects, there are discussions of making `yield` implicit in the coming versions of F#, see [F# RFC FS-1069 - Implicit yields](https://github.com/fsharp/fslang-design/blob/master/FSharp-4.7/FS-1069-implicit-yields.md).


### PR DESCRIPTION
Implicit yields have been available [for a while now](https://devblogs.microsoft.com/dotnet/announcing-f-4-7/).