### PR TITLE
Correct capitalization of javascript to JavaScript

### DIFF
--- a/chapters/commands/http.md
+++ b/chapters/commands/http.md
@@ -18,7 +18,7 @@ In the same way that the browser sends HTTP requests to the server, our Elmish a
 
 A common question developers ask when getting started with Elmish is: "How to work with HTTP in Elmish?" The short answer is to use Elmish commands and asynchronous workflows, but before getting into any of that we should rephrase the question into "How to work with HTTP in JavaScript?" It is easy to forget that Fable compiles to plain old JavaScript and that the techniques used in plain old JavaScript are still very much applicable in Fable and Elmish applications.
 
-There are many libraries in the javascript world to work with HTTP but they all depend upon a single foundational building block which is the so-called `XMLHttpRequest` object available in all browsers.
+There are many libraries in the JavaScript world to work with HTTP but they all depend upon a single foundational building block which is the so-called `XMLHttpRequest` object available in all browsers.
 
 The object `XMLHttpRequest` can be used to make HTTP requests from the browser to a web server and make it possible to process the HTTP responses returned from that server. Despite the historical name, `XMLHttpRequest` is not tied to just XML as a data format for data exchange. In fact, it can use any generic data format like JSON or raw binary data.
 

--- a/chapters/elm/counter.md
+++ b/chapters/elm/counter.md
@@ -137,7 +137,7 @@ For part (1), lets examine `dist/index.html`, we will see the placeholder elemen
 ```
 As for part (2), it is a bit more complicated. As we have discussed before, Elmish as an implementation of The Elm Architecture addresses two main concerns (1) managing and keeping track of data (= state) and (2) rendering user interface based on that state  (*re-rendering* the user interface whenever the state changes).
 
-The second concern (rendering user interfaces) is commonly referred to as the "view part" of The Elm Architecture. Elmish delegates this concern to a third-party library that knows how to work with user interfaces really well, in this case it is the [React.js](https://reactjs.org/) library, one of the three most popular libraries in the javascript ecosystem to build web applications. Section [React in Elmish](react-in-elmish) goes into greater details of this subject matter.
+The second concern (rendering user interfaces) is commonly referred to as the "view part" of The Elm Architecture. Elmish delegates this concern to a third-party library that knows how to work with user interfaces really well, in this case it is the [React.js](https://reactjs.org/) library, one of the three most popular libraries in the JavaScript ecosystem to build web applications. Section [React in Elmish](react-in-elmish) goes into greater details of this subject matter.
 
 Although React is only one type of these rendering engines, it is the most popular in the Fable community because it fits really well with the functional approach and because we can use a plethora of pre-existing React components in our Elmish applications without re-implementing them ourselves from scratch.
 

--- a/chapters/fable/fable-bindings.md
+++ b/chapters/fable/fable-bindings.md
@@ -1,8 +1,8 @@
 # Fable bindings
 
-Bindings are specialized Fable packages that allow a Fable project to access native javascript APIs. These packages hide away the complexity of JavaScript libraries behind type-safe and idiomatic F# code, checked for correctness by the powerful F# compiler and type system.
+Bindings are specialized Fable packages that allow a Fable project to access native JavaScript APIs. These packages hide away the complexity of JavaScript libraries behind type-safe and idiomatic F# code, checked for correctness by the powerful F# compiler and type system.
 
-When we talk about bindings, we are just talking about a shell for an underlying javascript API or library. This means that a Fable binding is *always* used in combination with some specific JavaScript code that the binding calls or interacts with under the hood.
+When we talk about bindings, we are just talking about a shell for an underlying JavaScript API or library. This means that a Fable binding is *always* used in combination with some specific JavaScript code that the binding calls or interacts with under the hood.
 
 Which binding you can use depends entirely on the platform or environment in which your compiled F# code is running. Different platforms provide different APIs; for example, the APIs available in the browser are different than those available on a Node.js runtime. In the browser, you can manipulate user interface elements and draw 2D shapes on a canvas. Meanwhile, on the Node.js side of things, you can read file contents, call cryptographic functions or host a web server.
 
@@ -10,7 +10,7 @@ There are more popular platforms that Fable can target, one of which is [Github 
 
 ### Types of bindings
 
-Because there are different platforms that Fable can target, we end up with different types of bindings that are applicable in each one of these platforms. Let's break down all the possibilities of javascript code that a Fable binding can interact with:
+Because there are different platforms that Fable can target, we end up with different types of bindings that are applicable in each one of these platforms. Let's break down all the possibilities of JavaScript code that a Fable binding can interact with:
 
  - Type 1: Globally available functions in every JavaScript runtime
    - `Math.*` functions such as `Math.random()`, `Math.sin()`, `Math.cos()` etc.
@@ -50,12 +50,12 @@ Because there are different platforms that Fable can target, we end up with diff
 
 The list above is quite involved, which is a consequence of how JavaScript code is used and distributed throughout the different platforms. Historically, you could only use JavaScript inside a browser, and the only libraries you could use were the ones you included in a web page using a script tag. A library included this way becomes globally available on the page as an object under the global `window` variable. Later on, a proper package registry was introduced along with the Node.js runtime, what is known today as [npm](https://www.npmjs.com/): the largest package registry of libraries in the world.
 
-Interacting with libraries included using a script tag in a web page is a different story than interacting with a library that is downloaded using `npm`. The former uses global variables, and the latter uses javascript modules for exposing the code.
+Interacting with libraries included using a script tag in a web page is a different story than interacting with a library that is downloaded using `npm`. The former uses global variables, and the latter uses JavaScript modules for exposing the code.
 Let's go through some example Fable bindings and explain on which target they would be compatible.
 
 ### Examples of Fable bindings
 
-The first example is one we used in the very first [Hello World](hello-world.md) application, the package `Fable.Browser.Dom`. Using this package, we were able to interact with the `document` object and manipulate UI elements on the page. `Fable.Browser.Dom` is a binding for Type 2 javascript code. This package is one of the family of Fable packages under the [Fable.Browser](https://www.nuget.org/packages?q=Fable.Browser) namespace designed to be used in the browser.
+The first example is one we used in the very first [Hello World](hello-world.md) application, the package `Fable.Browser.Dom`. Using this package, we were able to interact with the `document` object and manipulate UI elements on the page. `Fable.Browser.Dom` is a binding for Type 2 JavaScript code. This package is one of the family of Fable packages under the [Fable.Browser](https://www.nuget.org/packages?q=Fable.Browser) namespace designed to be used in the browser.
 
 The packages [Thoth.Json](https://github.com/thoth-org/Thoth.Json) and [Fable.SimpleJson](https://github.com/Zaid-Ajaj/Fable.SimpleJson), two general-purpose libraries for working with JSON are bindings of Type 1 because they both use the `JSON.*` module under the hood. These two can be used both inside the browser and Node.js runtime.
 
@@ -73,7 +73,7 @@ Type 4 packages are by far the most common bindings in Fable's ecosystem, simply
 
 <resolved-image source="/images/fable/type-four.png" />
 
-Fable bindings will usually prefer the modern `npm` modules. This means that a Fable binding, distributed to NuGet, has a *dependency* on a javascript package distributed to `npm`. In order to use these bindings of Type 4, you need to install the binding from NuGet and the actual library from npm. Let's take the [Fable.DateFunctions](https://github.com/Zaid-Ajaj/Fable.DateFunctions) package which is a binding for the native javascript library [date-fns](https://date-fns.org/). This library provides many useful functions to manipulate `DateTime`, and you can use it in your Fable projects through this binding.
+Fable bindings will usually prefer the modern `npm` modules. This means that a Fable binding, distributed to NuGet, has a *dependency* on a JavaScript package distributed to `npm`. In order to use these bindings of Type 4, you need to install the binding from NuGet and the actual library from npm. Let's take the [Fable.DateFunctions](https://github.com/Zaid-Ajaj/Fable.DateFunctions) package which is a binding for the native JavaScript library [date-fns](https://date-fns.org/). This library provides many useful functions to manipulate `DateTime`, and you can use it in your Fable projects through this binding.
 
 To use it inside your project, you have to install both `Fable.DateFunction` from NuGet and `date-fns` from npm:
 
@@ -88,4 +88,4 @@ This may sound worrisome since you have to know which versions of npm packages g
 
 ### Authoring Fable libraries and bindings
 
-This was just a glimpse at how Fable packages can integrate native javascript modules into Fable applications. In chapter 5, we will be looking into interoperability in great detail and the different ways of authoring a Fable package.
+This was just a glimpse at how Fable packages can integrate native JavaScript modules into Fable applications. In chapter 5, we will be looking into interoperability in great detail and the different ways of authoring a Fable package.

--- a/chapters/fable/how-fable-works.md
+++ b/chapters/fable/how-fable-works.md
@@ -8,4 +8,4 @@ This diagram below shows an overview of the process.
 
 <resolved-image source="/images/fable/fable.png" />
 
-The generated JavaScript doesn't have to be a minified JavaScript file. This is only the convention when compiling F# source code for the browser. When building F# projects for Node.js environments, the output can be multiple javascript files referencing (i.e. `requiring`) each other while preserving the same input F# project structure that Fable compiled.
+The generated JavaScript doesn't have to be a minified JavaScript file. This is only the convention when compiling F# source code for the browser. When building F# projects for Node.js environments, the output can be multiple JavaScript files referencing (i.e. `requiring`) each other while preserving the same input F# project structure that Fable compiled.

--- a/chapters/fable/node-packages.md
+++ b/chapters/fable/node-packages.md
@@ -53,7 +53,7 @@ You might have wondered: "How did Fable compile the project if I didn't install 
 
 ### Npm scripts
 
-The latter section of `package.json` is the `scripts` sections, also known as npm scripts. This section provides shortcuts to *running* the cli programs that were installed as development dependencies or any shell command from the system. For example, we installed `webpack` and `webpack-dev-server` which are programs that work with Fable to turn the F# project into a nicely bundled javascript file. We provide shortcuts to run these programs using the npm scripts `start` and `build`. To run such a script, you run the command:
+The latter section of `package.json` is the `scripts` sections, also known as npm scripts. This section provides shortcuts to *running* the cli programs that were installed as development dependencies or any shell command from the system. For example, we installed `webpack` and `webpack-dev-server` which are programs that work with Fable to turn the F# project into a nicely bundled JavaScript file. We provide shortcuts to run these programs using the npm scripts `start` and `build`. To run such a script, you run the command:
 ```bash
 npm run <script name>
 ```

--- a/chapters/fable/observations.md
+++ b/chapters/fable/observations.md
@@ -4,7 +4,7 @@ You might be wondering why we made the trivial counter application in the previo
 
 ### Fable is a general-purpose compiler
 
-Assuming you have done any JavaScript development before, you surely have noticed how similar the F# code looked like in the first listing. In fact, if I was using pure javascript to implement the same app it would look something like this:
+Assuming you have done any JavaScript development before, you surely have noticed how similar the F# code looked like in the first listing. In fact, if I was using pure JavaScript to implement the same app it would look something like this:
 ```js
 const increase = document.getElementById("increase")
 const decrease = document.getElementById("decrease")
@@ -38,7 +38,7 @@ In the previous example, we used two different constructs: mutability and `async
 
 ### F# Async in JavaScript
 
-As for `async`, it is natural for Fable to support that construct because the javascript runtime make heavy use of continuations, also known as callbacks. In fact, many if not all native javascript callback-based APIs can be turned into `async` expressions quite easily, for example, to convert [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout) in javascript into an async "sleep" function, you can write the following:
+As for `async`, it is natural for Fable to support that construct because the JavaScript runtime make heavy use of continuations, also known as callbacks. In fact, many if not all native JavaScript callback-based APIs can be turned into `async` expressions quite easily, for example, to convert [setTimeout](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout) in JavaScript into an async "sleep" function, you can write the following:
 
 ```fsharp
 open Fable.Core
@@ -65,7 +65,7 @@ async {
 <code>Async.Sleep</code> with Fable is implemented using <code>setTimeout</code> under the hood, however the implementation is more advanced and provides built-in support for cancellation.
 </div>
 
-The above snippet uses native javascript and makes use of Fable's interop capabilities. Don't worry if you do not understand this right away because of the `Emit` attribute or the `jsNative` value; there will be a whole chapter devoted to interoperability from Fable. The take away from this is that it is straightforward and easy to use native functionality when needed.
+The above snippet uses native JavaScript and makes use of Fable's interop capabilities. Don't worry if you do not understand this right away because of the `Emit` attribute or the `jsNative` value; there will be a whole chapter devoted to interoperability from Fable. The take away from this is that it is straightforward and easy to use native functionality when needed.
 
 
 ### Unsupported Features


### PR DESCRIPTION
Thank you for accepting my previous PR that corrected (some) of the capitalization of JavaScript. In that previous PR, I changed `Javascript` (title case) to `JavaScript` (Pascal case). However, I failed to change `javascript` (all lower case) to `JavaScript` (Pascal case). This PR replaces the lower case instances.