### PR TITLE
Add a link to your "F# Interop with Javascript in Fable: The Complete Guide" medium article

### DIFF
--- a/chapters/fable/fable-bindings.md
+++ b/chapters/fable/fable-bindings.md
@@ -89,3 +89,5 @@ This may sound worrisome since you have to know which versions of npm packages g
 ### Authoring Fable libraries and bindings
 
 This was just a glimpse at how Fable packages can integrate native JavaScript modules into Fable applications. In chapter 5, we will be looking into interoperability in great detail and the different ways of authoring a Fable package.
+
+If you would like to find out more about how to write bindings, here is a write-up of my own on Medium. It is a little out of date, e.g. Pojo attributes, but the ideas are pretty much the same. [F# Interop with Javascript in Fable: The Complete Guide](https://medium.com/@zaid.naom/f-interop-with-javascript-in-fable-the-complete-guide-ccc5b896a59f)


### PR DESCRIPTION
I saw this link in Slack and thought it was useful. I'd read the book a few months previous, but recently returned to see more information regarding how to write fable bindings, but couldn't see any specifics.

This feels like a good stop gap, even if slightly out of date.