### PR TITLE
Update Feliz.Router samples for version 3.x

### DIFF
--- a/chapters/scaling/introducing-url-type.md
+++ b/chapters/scaling/introducing-url-type.md
@@ -40,9 +40,9 @@ let render (state: State) (dispatch: Msg -> unit) =
     | Url.User userId -> Html.h1 (sprintf "UserId: %d" userId)
     | Url.NotFound -> Html.h1 "Not Found"
 
-  Router.router [
-    Router.onUrlChanged (parseUrl >> UrlChanged >> dispatch)
-    Router.application [ activePage ]
+  React.router [
+    router.onUrlChanged (parseUrl >> UrlChanged >> dispatch)
+    router.children [ activePage ]
   ]
 ```
 Now this is a much cleaner solution. However, it is very important to understand how the `Url` correlates to the `Page` type. I have seen frameworks that model both in one type and make a mess out of it. The `Url` is not to be mapped one-to-one into a `Page` instance, but rather it should contain enough information for the **initialization** of a `Page`. Suppose I have the following types:

--- a/chapters/scaling/parsing-url-segments.md
+++ b/chapters/scaling/parsing-url-segments.md
@@ -15,9 +15,9 @@ let render (state: State) (dispatch: Msg -> unit) =
     | [ "user"; Route.Int userId ] -> Html.h1 (sprintf "UserId: %d" userId)
     | _ -> Html.h1 "Not Found"
 
-  Router.router [
-    Router.onUrlChanged (UrlChanged >> dispatch)
-    Router.application [ activePage ]
+  React.router [
+    router.onUrlChanged (UrlChanged >> dispatch)
+    router.children [ activePage ]
   ]
 ```
 That parsed integer `userId` is made available in the scope and can be used in the render function dynamically. The `Route` module contains more patterns like the one above:
@@ -50,9 +50,9 @@ let render (state: State) (dispatch: Msg -> unit) =
     | [ "user"; Route.Query [ "id", Route.Int userId ] ] -> Html.h1 (sprintf "UserId: %d" userId)
     | _ -> Html.h1 "Not Found"
 
-  Router.router [
-    Router.onUrlChanged (UrlChanged >> dispatch)
-    Router.application [ activePage ]
+  React.router [
+    router.onUrlChanged (UrlChanged >> dispatch)
+    router.children [ activePage ]
   ]
 ```
 Of course, you can pattern match against multiple parameters using the same list of query string parameters. Suppose we have a "search" page which has two parameters: `query` and `limit`. The first parameter is the string that we want to look for and the second parameter is optional and specifies the maximum number of search results to show on screen. Then we can pattern match that page as follows:

--- a/chapters/scaling/programmatic-navigation.md
+++ b/chapters/scaling/programmatic-navigation.md
@@ -1,6 +1,6 @@
 # Programmatic Navigation
 
-Using anchor tags with `Html.a` elements is not the only way to navigate from one page to another. In fact, most of the times you want to navigate to another page as a result of an *event* using commands. Take the example where you want to navigate from the login page to the home page after a successful login attempt. This type of navigation only kicks into play after a login operation finishes running, rather than an immediate click of a link on the page. The `Feliz.Router` package provides a handy overloaded function called `navigate` from the `Router` module which returns a command that programmatically changes the current URL of the page. This in turn causes the `onUrlChanged` event to trigger once more and the rest of the application to react to that change.
+Using anchor tags with `Html.a` elements is not the only way to navigate from one page to another. In fact, most of the times you want to navigate to another page as a result of an *event* using commands. Take the example where you want to navigate from the login page to the home page after a successful login attempt. This type of navigation only kicks into play after a login operation finishes running, rather than an immediate click of a link on the page. The `Feliz.Router` package provides a handy overloaded function called `navigate` from the `Cmd` module which returns a command that programmatically changes the current URL of the page. This in turn causes the `onUrlChanged` event to trigger once more and the rest of the application to react to that change.
 
 Let us take an example by navigating to pages as a result of an event. First of all we will introduce two messages, each of which cause the application to navigate to a different page:
 ```fsharp {highlight: [6, 7]}
@@ -19,13 +19,13 @@ Then from the `update` function have these messages trigger the `navigate` comma
 let update (msg: Msg) (state: State) =
   match msg with
   | UrlChanged url -> { state with CurrentUrl = url }, Cmd.none
-  | NavigateToContact ->  state, Router.navigate("contact")
-  | NavigateToAbout -> state, Router.navigate("about")
+  | NavigateToContact ->  state, Cmd.navigate("contact")
+  | NavigateToAbout -> state, Cmd.navigate("about")
 ```
-The `Router.navigate` function can be called the same way as `Router.format`. It takes route segments as input and optionally it can take query string parameters as the last argument:
- - `Router.navigate("segment1", "segment2", "segment3")` => `/segment1/segment2/segment3`
- - `Router.navigate("user", [ "userId", 42 ])` => `/user?userId=42`
- - `Router.navigate("albums", [ "search", "tayler swift" ])` => `/albums?search=tayler%20swift`
+The `Cmd.navigate` function can be called the same way as `Router.format`. It takes route segments as input and optionally it can take query string parameters as the last argument:
+ - `Cmd.navigate("segment1", "segment2", "segment3")` => `/segment1/segment2/segment3`
+ - `Cmd.navigate("user", [ "userId", 42 ])` => `/user?userId=42`
+ - `Cmd.navigate("albums", [ "search", "tayler swift" ])` => `/albums?search=tayler%20swift`
 
 Finally, we need to trigger these events somehow. A couple of buttons with click events from the user interface will do:
 ```fsharp {highlight: ['13-17', '19-23']}
@@ -37,9 +37,9 @@ let render (state: State) (dispatch: Msg -> unit) =
     | [ "contact" ] -> Html.h1 "Contact"
     | _ -> Html.h1 "Not Found"
 
-  Router.router [
-    Router.onUrlChanged (UrlChanged >> dispatch)
-    Router.application [
+  React.router [
+    router.onUrlChanged (UrlChanged >> dispatch)
+    router.children [
 
       Html.button [
         prop.text "Contact"

--- a/chapters/scaling/routing.md
+++ b/chapters/scaling/routing.md
@@ -68,13 +68,15 @@ let update (msg: Msg) (state: State): State =
   match msg with
   | UrlChanged url -> { state with CurrentUrl = url }
 ```
-Within the `Feliz.Router` namespace, we primarily use two modules:
- - `Router` which contains functions to work with and listen to URLs.
- - `Route` which contains active patterns to parse URL segments easily.
+The `Feliz.Router` namespace brings into scope these routing helpers:
+ - `Router` module which contains functions to work with and listen to URLs.
+ - `Route` module which contains active patterns to parse URL segments easily.
+ - `Cmd` functions for creating URL-related Elmish commands.
+ - `React.router` extension method for rendering the React-based router itself.
 
 The first function to use from the `Router` module is `currentUrl()` which parses the URL of the page that the application has landed on into URL segments. The parsed segments will be the initial value for the `CurrentUrl`.
 
-Much more interesting is what is happening in the `render` function. Here we will use the `router` function from the `Router` module and use it as if it was a UI element:
+Much more interesting is what is happening in the `render` function. Here we will use the `router` extention method for the `React` class:
 ```fsharp {highlight: ['12-15']}
 open Feliz
 open Feliz.Router


### PR DESCRIPTION
According to https://github.com/Zaid-Ajaj/Feliz.Router#migrating-from-2x-to-3x, the 3.x version of Feliz.Router made some changes to the API. Specifically...

* `Router.router` becomes `React.router`
* `Router.onUrlChanged` becomes `router.onUrlChanged`
* `Router.application` becomes `router.children`
* `Router.navigate` becomes `Cmd.navigate` for the Elmish variant and `Router.navigate() : unit` for the React variant

This PR updates the code samples in The Elmish Book to reflect those changes.

Resolves #173.